### PR TITLE
Expose ssl.strict configuration

### DIFF
--- a/lib/login.js
+++ b/lib/login.js
@@ -1,5 +1,5 @@
 var RegClient = require('npm-registry-client');
-var client = new RegClient({});
+var client = new RegClient({"ssl.strict": false});
 var fs = require('fs');
 var path = require('path');
 

--- a/lib/login.js
+++ b/lib/login.js
@@ -1,5 +1,10 @@
 var RegClient = require('npm-registry-client');
-var client = new RegClient({"ssl.strict": false});
+// set configuration based on environment variables...
+var config = {};
+if (process.env.NCL_SSL_STRICT == 'false') {
+    (config.ssl || (config.ssl = {})).strict = false;
+}
+var client = new RegClient(config);
 var fs = require('fs');
 var path = require('path');
 


### PR DESCRIPTION
Allow setting the `ssl.strict` flag on the underlying [`npm-registry-client`](https://github.com/npm/npm-registry-client#configuration), to allow publishing to repositories with self-signed certificates.

This is facilitated, by setting the environment variable `NCL_SSL_STRICT` to `false`.

**e.g.**
```shell
export NCL_SSL_STRICT=false
npm-cli-login -u admin -p admin123 -e nick@foo.bar -r https://repo/repository/npm-internal
```

(Ideally it would be better to expose all settings, specifically `ssl.ca`, and not just skipping ssl verification, but I'll leave that for another day.)